### PR TITLE
Update for Ruby 2.2

### DIFF
--- a/lib/auto_click.rb
+++ b/lib/auto_click.rb
@@ -1,4 +1,4 @@
-require 'dl/import'
+require 'fiddle/import'
 require 'auto_click/input_structure'
 require 'auto_click/virtual_key'
 require 'auto_click/user32'

--- a/lib/auto_click/user32.rb
+++ b/lib/auto_click/user32.rb
@@ -1,5 +1,5 @@
 module User32
-  extend DL::Importer
+  extend Fiddle::Importer
   dlload 'user32'
   extern "int GetCursorPos(char*)"
   extern "int SetCursorPos(int,int)"

--- a/lib/auto_click/version.rb
+++ b/lib/auto_click/version.rb
@@ -1,3 +1,3 @@
 module AutoClick
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
In Ruby 2.2+ (or even lower) DL library is no longer available. Fiddle has the same functionality, so only 2 lines of code needed to be changed.